### PR TITLE
Change inheritance order of the `ProofConsumer`

### DIFF
--- a/erc20-bridge-token/contracts/BridgeTokenFactory.sol
+++ b/erc20-bridge-token/contracts/BridgeTokenFactory.sol
@@ -17,10 +17,10 @@ import "./ResultsDecoder.sol";
 import "./SelectivePausableUpgradable.sol";
 
 contract BridgeTokenFactory is
+    ProofConsumer,
     UUPSUpgradeable,
     AccessControlUpgradeable,
-    SelectivePausableUpgradable,
-    ProofConsumer
+    SelectivePausableUpgradable
 {
     using Borsh for Borsh.Data;
     using SafeERC20 for IERC20;
@@ -190,6 +190,7 @@ contract BridgeTokenFactory is
     function pauseWithdraw() external onlyRole(PAUSABLE_ADMIN_ROLE) {
         _pause(pausedFlags() | PAUSED_WITHDRAW);
     }
+
     function pauseAll() external onlyRole(PAUSABLE_ADMIN_ROLE) {
         uint flags = PAUSED_DEPOSIT | PAUSED_WITHDRAW;
         _pause(flags);


### PR DESCRIPTION
In the new contracts the `ProofConsumer` is inherited last which makes determining the slot position of `usedProofs` a bit tricky with C3 linearization. We use the slot position to binary search the transaction which finalizes a transfer.