### PR TITLE
Fix lack check of bridge token id

### DIFF
--- a/erc20-bridge-token/contracts/BridgeTokenFactory.sol
+++ b/erc20-bridge-token/contracts/BridgeTokenFactory.sol
@@ -58,7 +58,13 @@ contract BridgeTokenFactory is
 
     event Deposit(string indexed token, uint256 amount, address recipient);
 
-    event SetMetadata(address indexed token, string name, string symbol, uint8 decimals);
+    event SetMetadata(
+        address indexed token,
+        string tokenId,
+        string name,
+        string symbol,
+        uint8 decimals
+    );
 
     // BridgeTokenFactory is linked to the bridge token factory on NEAR side.
     // It also links to the prover that it uses to unlock the tokens.
@@ -123,7 +129,13 @@ contract BridgeTokenFactory is
             )
         );
 
-        emit SetMetadata(bridgeTokenProxy, result.name, result.symbol, result.decimals);
+        emit SetMetadata(
+            bridgeTokenProxy,
+            result.token,
+            result.name,
+            result.symbol,
+            result.decimals
+        );
 
         _isBridgeToken[address(bridgeTokenProxy)] = true;
         _ethToNearToken[address(bridgeTokenProxy)] = result.token;
@@ -143,7 +155,13 @@ contract BridgeTokenFactory is
 
         bridgeToken.setMetadata(name, symbol, bridgeToken.decimals());
 
-        emit SetMetadata(address(bridgeToken), name, symbol, bridgeToken.decimals());
+        emit SetMetadata(
+            address(bridgeToken),
+            token,
+            name,
+            symbol,
+            bridgeToken.decimals()
+        );
     }
 
     function deposit(

--- a/erc20-bridge-token/contracts/BridgeTokenFactory.sol
+++ b/erc20-bridge-token/contracts/BridgeTokenFactory.sol
@@ -98,12 +98,9 @@ contract BridgeTokenFactory is
     }
 
     function newBridgeToken(
-        string calldata nearTokenId,
         bytes memory proofData,
         uint64 proofBlockHeight
     ) external returns (address) {
-        require(!_isBridgeToken[_nearToEthToken[nearTokenId]], "ERR_TOKEN_EXIST");
-
         ProofDecoder.ExecutionStatus memory status = _parseAndConsumeProof(
             proofData,
             proofBlockHeight
@@ -111,6 +108,8 @@ contract BridgeTokenFactory is
         ResultsDecoder.MetadataResult memory result = ResultsDecoder.decodeMetadataResult(
             status.successValue
         );
+
+        require(!_isBridgeToken[_nearToEthToken[result.token]], "ERR_TOKEN_EXIST");
 
         address bridgeTokenProxy = address(
             new ERC1967Proxy(
@@ -127,8 +126,8 @@ contract BridgeTokenFactory is
         emit SetMetadata(bridgeTokenProxy, result.name, result.symbol, result.decimals);
 
         _isBridgeToken[address(bridgeTokenProxy)] = true;
-        _ethToNearToken[address(bridgeTokenProxy)] = nearTokenId;
-        _nearToEthToken[nearTokenId] = address(bridgeTokenProxy);
+        _ethToNearToken[address(bridgeTokenProxy)] = result.token;
+        _nearToEthToken[result.token] = address(bridgeTokenProxy);
 
         return bridgeTokenProxy;
     }


### PR DESCRIPTION
* Fix the possibility of deploying new tokens with incorrect metadata.
* Add near token id to the metadata event