### PR TITLE
Minor audit fixes

### DIFF
--- a/erc20-bridge-token/contracts/BridgeToken.sol
+++ b/erc20-bridge-token/contracts/BridgeToken.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.24;
 
 import {ERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
-import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {Ownable2StepUpgradeable} from "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
@@ -10,7 +10,7 @@ contract BridgeToken is
     Initializable,
     UUPSUpgradeable,
     ERC20Upgradeable,
-    OwnableUpgradeable
+    Ownable2StepUpgradeable
 {
     string private _name;
     string private _symbol;

--- a/erc20-bridge-token/contracts/BridgeTokenFactory.sol
+++ b/erc20-bridge-token/contracts/BridgeTokenFactory.sol
@@ -184,7 +184,7 @@ contract BridgeTokenFactory is
 
     function withdraw(
         string memory token,
-        uint256 amount,
+        uint128 amount,
         string memory recipient
     ) external whenNotPaused(PAUSED_WITHDRAW) {
         _checkWhitelistedToken(token, msg.sender);

--- a/erc20-bridge-token/contracts/ProofConsumer.sol
+++ b/erc20-bridge-token/contracts/ProofConsumer.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.24;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
-
 import "rainbow-bridge-sol/nearprover/contracts/INearProver.sol";
 import "rainbow-bridge-sol/nearprover/contracts/ProofDecoder.sol";
 import "rainbow-bridge-sol/nearbridge/contracts/Borsh.sol";

--- a/erc20-bridge-token/contracts/SelectivePausableUpgradable.sol
+++ b/erc20-bridge-token/contracts/SelectivePausableUpgradable.sol
@@ -38,8 +38,6 @@ abstract contract SelectivePausableUpgradable is Initializable, ContextUpgradeab
      */
     event Paused(address account, uint flags);
 
-    uint private _pausedFlags;
-
     /**
      * @dev Initializes the contract in unpaused state.
      */


### PR DESCRIPTION
* Remove unused import `Ownable.sol`.
* Remove unused `_pausedFlags`.
* Change withdraw argument type from u256 to u128 to avoid potential overflow.
* Replace `OwnableUpgradeable` with `Ownable2StepUpgradeable`