### PR TITLE
Add mint and burn function for OmniBridge Migration

### DIFF
--- a/erc20-bridge-token/contracts/BridgeTokenFactory.sol
+++ b/erc20-bridge-token/contracts/BridgeTokenFactory.sol
@@ -190,6 +190,16 @@ contract BridgeTokenFactory is
         emit Withdraw(token, msg.sender, amount, recipient, tokenEthAddress);
     }
 
+    function mint(address token, address to, uint128 amount) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        require(_isBridgeToken[token], "ERR_NOT_BRIDGE_TOKEN");
+        BridgeToken(token).mint(to, amount);
+    }
+
+    function burn(address token, uint128 amount) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        require(_isBridgeToken[token], "ERR_NOT_BRIDGE_TOKEN");
+        BridgeToken(token).burn(address(this), amount);
+    }
+
     function pause(uint flags) external onlyRole(DEFAULT_ADMIN_ROLE) {
         _pause(flags);
     }


### PR DESCRIPTION
We have several options for migrating the NEP-141 token connector to OmniBridge.

The first option is to change the owner of the ERC-20 tokens (the mirror of the native NEP-141) to OmniBridge. This is not such a bad option, considering that we only have one token. The downside is that old transfers cannot be finalized. However, to be honest, I don’t think we’ll have any. This plan is technically more complex in terms of the migration process itself. We would need to add a tokenOwnerTransfer function to BridgeTokenFactory and an acceptTokensOwnership function to OmniBridge. But it might still be a good option.

The second, simpler option is to add mint and burn functions to BridgeTokenFactory and use this contract as a CustomMinter for these tokens (see [OmniBridge.sol#L64](https://github.com/Near-One/omni-bridge/blob/main/evm/src/omni-bridge/contracts/OmniBridge.sol#L64)). In this case, OmniBridge would be set as the admin for BridgeTokenFactory.

Another option is not to make OmniBridge the admin but to add an additional role for mint and burn. However, I found making OmniBridge the admin to be a more appropriate approach.